### PR TITLE
Fix shell injection, safe command tagged template literal

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": false,
+  "singleQuote": true
+}

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -2,11 +2,11 @@ import { Buffer } from 'node:buffer'
 import { PathLike } from 'node:fs'
 
 export type Command =
-  | { type: 'spawn', executable: string, args: string[] }
-  | { type: 'pipe', lhs: Command, rhs: Command }
-  | { type: 'and', lhs: Command, rhs: Command }
-  | { type: 'or', lhs: Command, rhs: Command }
-  | { type: 'redirectStdout', cmd: Command, path: PathLike }
-  | { type: 'redirectStderr', cmd: Command, path: PathLike }
-  | { type: 'redirectStdin', cmd: Command, path: PathLike }
-  | { type: 'writeStdin', cmd: Command, data: Buffer }
+  | { type: 'spawn'; executable: string; args: string[] }
+  | { type: 'pipe'; lhs: Command; rhs: Command }
+  | { type: 'and'; lhs: Command; rhs: Command }
+  | { type: 'or'; lhs: Command; rhs: Command }
+  | { type: 'redirectStdout'; cmd: Command; path: PathLike }
+  | { type: 'redirectStderr'; cmd: Command; path: PathLike }
+  | { type: 'redirectStdin'; cmd: Command; path: PathLike }
+  | { type: 'writeStdin'; cmd: Command; data: Buffer }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -5,7 +5,7 @@ import { PathLike } from 'node:fs'
 import * as errors from './errors'
 import * as ast from './ast'
 import evalCommand from './eval'
-
+import { quote, toShellScript } from './toShellScript'
 
 const readStream = async (stream: Readable): Promise<Buffer> => {
   const chunks = []
@@ -64,16 +64,13 @@ export class CommandBuilder {
     try {
       await stdio.terminated
       exitCode = 0
-    }
-    catch (err) {
+    } catch (err) {
       if (err instanceof errors.NonZeroExitCode) {
         exitCode = err.code
-      }
-      else {
+      } else {
         console.error(err)
       }
-    }
-    finally {
+    } finally {
       if (stdio.stdout instanceof Duplex) {
         stdio.stdout.end()
       }
@@ -89,7 +86,85 @@ export class CommandBuilder {
       stderr,
     }
   }
+
+  toShellScript(): string {
+    return toShellScript(this.node)
+  }
 }
 
-export const command = (executable: string, ...args: string[]) =>
-  new CommandBuilder({ type: 'spawn', executable, args })
+type CommandTemplateArg =
+  /** String arguments will be shell-escaped. */
+  | string
+  /** Command arguments will be interpolated literally. */
+  | CommandBuilder
+  /** Null and undefined arguments are omitted entirely. */
+  | null
+  | undefined
+
+function unexpectedArgToString(arg: unknown): string {
+  const constructorName = (
+    arg as undefined | { constructor?: { name?: string } }
+  )?.constructor?.name
+  return `${typeof arg}/${constructorName || 'no constructor'}: ${String(arg)}`
+}
+
+function commandFromTaggedTemplateLiteral(
+  template: string[],
+  ...args: CommandTemplateArg[]
+) {
+  const executable = template
+    .map((str, i) => {
+      const arg = args[i]
+      if (arg === null || arg === undefined) return str
+      if (typeof arg === 'string') return `${str}${quote(arg)}`
+      if (arg instanceof CommandBuilder) return `${str}${arg.toShellScript()}`
+      else {
+        arg satisfies never
+        throw new TypeError(
+          `Expected command template argument [${i}] to be string, Command, or nullable, but was ${unexpectedArgToString(
+            arg
+          )}`
+        )
+      }
+    })
+    .join(' ')
+
+  return new CommandBuilder({ type: 'spawn', executable, args: [] })
+}
+
+function commandFromExecutableAndArgs(
+  executable: string,
+  ...args: string[]
+): CommandBuilder {
+  return new CommandBuilder({ type: 'spawn', executable, args })
+}
+
+export function command(executable: string, ...args: string[]): CommandBuilder
+export function command(
+  template: TemplateStringsArray,
+  ...args: Array<CommandTemplateArg>
+): CommandBuilder
+export function command(
+  executableOrTemplate: string | TemplateStringsArray,
+  ...args: Array<string> | Array<CommandTemplateArg>
+): CommandBuilder {
+  if (typeof executableOrTemplate === 'string') {
+    const stringArgs = args.map((arg, i) => {
+      if (typeof arg !== 'string') {
+        throw new TypeError(
+          `Expected command argument [${i}] to be string, but was ${unexpectedArgToString(
+            arg
+          )}}`
+        )
+      }
+      return arg
+    })
+    return commandFromExecutableAndArgs(executableOrTemplate, ...stringArgs)
+  } else if (Array.isArray(executableOrTemplate)) {
+    return commandFromTaggedTemplateLiteral(executableOrTemplate, ...args)
+  } else {
+    throw new TypeError(
+      `Unexpected executable: ${unexpectedArgToString(executableOrTemplate)}`
+    )
+  }
+}

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 
 import * as errors from './errors'
 import { Command } from './ast'
+import { quote } from './toShellScript'
 
 export interface Stdio {
   stdin: Writable,
@@ -15,14 +16,10 @@ export interface Stdio {
 const evalCommand = async (node: Command): Promise<Stdio> => {
   switch (node.type) {
     case 'spawn': {
-      const child = spawn(
-        node.executable,
-        node.args,
-        {
-          shell: true,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        },
-      )
+      const child = spawn(node.executable, node.args.map(quote), {
+        shell: true,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
 
       const terminated = new Promise<void>((resolve, reject) => {
         child.on('close', (code, signal) => {

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -7,10 +7,10 @@ import { Command } from './ast'
 import { quote } from './toShellScript'
 
 export interface Stdio {
-  stdin: Writable,
-  stdout: Readable,
-  stderr: Readable,
-  terminated: Promise<void>,
+  stdin: Writable
+  stdout: Readable
+  stderr: Readable
+  terminated: Promise<void>
 }
 
 const evalCommand = async (node: Command): Promise<Stdio> => {
@@ -26,12 +26,10 @@ const evalCommand = async (node: Command): Promise<Stdio> => {
           if (code !== null) {
             if (code === 0) {
               resolve()
-            }
-            else {
+            } else {
               reject(new errors.NonZeroExitCode(code))
             }
-          }
-          else {
+          } else {
             reject(new errors.ProcessTerminated(signal!))
           }
         })
@@ -115,14 +113,13 @@ const evalCommand = async (node: Command): Promise<Stdio> => {
 
       const terminated = lhs.terminated
         .catch(() =>
-          evalCommand(node.rhs)
-            .then((rhs) => {
-              rhs.stdin.end()
-              rhs.stdout.pipe(stdout, { end: false })
-              rhs.stderr.pipe(stderr, { end: false })
+          evalCommand(node.rhs).then((rhs) => {
+            rhs.stdin.end()
+            rhs.stdout.pipe(stdout, { end: false })
+            rhs.stderr.pipe(stderr, { end: false })
 
-              return rhs.terminated
-            })
+            return rhs.terminated
+          })
         )
         .finally(() => {
           stdout.end()
@@ -143,8 +140,7 @@ const evalCommand = async (node: Command): Promise<Stdio> => {
       const target = fs.createWriteStream(node.path)
       cmd.stdout.pipe(target, { end: false })
 
-      const terminated = cmd.terminated
-        .finally(() => target.end())
+      const terminated = cmd.terminated.finally(() => target.end())
 
       return {
         stdin: cmd.stdin,
@@ -160,8 +156,7 @@ const evalCommand = async (node: Command): Promise<Stdio> => {
       const target = fs.createWriteStream(node.path)
       cmd.stderr.pipe(target, { end: false })
 
-      const terminated = cmd.terminated
-        .finally(() => target.end())
+      const terminated = cmd.terminated.finally(() => target.end())
 
       return {
         stdin: cmd.stdin,

--- a/src/toShellScript.ts
+++ b/src/toShellScript.ts
@@ -1,0 +1,41 @@
+import { Command } from './ast'
+
+function unreachable(x: never): never {
+  throw new Error(`Unreachable: ${JSON.stringify(x)}`)
+}
+
+export function toShellScript(command: Command): string {
+  switch (command.type) {
+    case 'spawn':
+      return [command.executable, ...command.args.map(quote)].join(' ')
+    case 'pipe':
+      return `${toShellScript(command.lhs)} | ${toShellScript(command.rhs)}`
+    case 'and':
+      return `(${toShellScript(command.lhs)}) && ${toShellScript(command.rhs)}`
+    case 'or':
+      return `(${toShellScript(command.lhs)}) || ${toShellScript(command.rhs)}`
+    case 'redirectStdout':
+      return `(${toShellScript(command.cmd)}) > ${quote(String(command.path))}`
+    case 'redirectStderr':
+      return `(${toShellScript(command.cmd)}) 2> ${quote(String(command.path))}`
+    case 'redirectStdin':
+      return `(${toShellScript(command.cmd)}) < ${quote(String(command.path))}`
+    case 'writeStdin': {
+      // Not sure how safe it is to pass binary data through quoting, etc.
+      // Instead, pass as base64 decoded by the shell.
+      const dataBase64 = command.data.toString('base64')
+      return `${toShellScript(
+        command.cmd
+      )} <<< "$(base64 -d <<< ${dataBase64})"`
+    }
+    default:
+      unreachable(command)
+  }
+}
+
+/** Makes string `s` safe to interpolate as a shell argument. */
+export function quote(s: string) {
+  if (s === '') return `''`
+  if (!/[^%+,-./:=@_0-9A-Za-z]/.test(s)) return s
+  return `'` + s.replace(/'/g, `'"'`) + `'`
+}

--- a/tests/__snapshots__/index.spec.ts.snap
+++ b/tests/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`command runner should chain commands with && 1`] = `"(printf 'hello ') && printf world"`;
+
+exports[`command runner should chain commands with || 1`] = `"(exit 1) || echo 'hello world'"`;
+
+exports[`command runner should pipe stdout to stdin 1`] = `"echo 'hello world' | tr -d '\\r' | tr -d '\\n' | wc -c"`;
+
+exports[`command runner should redirect a file to stdin 1`] = `"(cat) < /var/folders/6f/y7zxg6h56r38gv53tqxxcwv00000gq/T/tshellout-test-stdin-v210dP/stdin.txt"`;
+
+exports[`command runner should redirect stderr to a file 1`] = `"(>&2 echo 'hello world') 2> /var/folders/6f/y7zxg6h56r38gv53tqxxcwv00000gq/T/tshellout-test-stderr-appOr5/stderr.txt"`;
+
+exports[`command runner should redirect stdout to a file 1`] = `"(echo 'hello world') > /var/folders/6f/y7zxg6h56r38gv53tqxxcwv00000gq/T/tshellout-test-stdout-GzEXzC/stdout.txt"`;
+
+exports[`command runner should return exit code 1`] = `"exit 42"`;
+
+exports[`command runner should return stderr 1`] = `">&2 echo 'hello world'"`;
+
+exports[`command runner should return stdout 1`] = `"echo 'hello world'"`;
+
+exports[`command runner should short-circuit on failure with && 1`] = `"(exit 1) && echo 'hello world'"`;
+
+exports[`command runner should short-circuit on success with || 1`] = `"(echo 'hello world') || exit 1"`;
+
+exports[`command runner should write to stdin 1`] = `"cat <<< "$(base64 -d <<< aGVsbG8gd29ybGQK)""`;
+
+exports[`command template literal inserts interpolated commands literally 1`] = `"echo Running command: exit 0 "`;
+
+exports[`command template literal omits interpolated null | undefined 1`] = `"echo   hi"`;
+
+exports[`command template literal omits interpolated null | undefined 2`] = `"echo   bye"`;
+
+exports[`command template literal shell-escapes interpolated strings 1`] = `"echo 'hello world' "`;

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -3,156 +3,216 @@ import path from 'node:path'
 import os from 'node:os'
 
 import command from '../src/index'
+import { CommandBuilder } from '../src/builder'
 
+const snapshotCommand = (cmd: CommandBuilder) => {
+  expect(cmd.toShellScript()).toMatchSnapshot()
+}
+
+const testCommand = async (
+  cmd: CommandBuilder,
+  block: (
+    res: Awaited<ReturnType<CommandBuilder['run']>>
+  ) => void | Promise<void>
+): Promise<void> => {
+  const resFromEval = await cmd.run()
+  await block(resFromEval)
+
+  const shellScript = cmd.toShellScript()
+  expect(shellScript).toMatchSnapshot()
+
+  const resFromShell = await command(shellScript).run()
+  try {
+    await block(resFromShell)
+  } catch (error) {
+    console.error(
+      'Bad shell script:\n',
+      shellScript,
+      '\nexitCode:',
+      resFromShell.exitCode,
+      '\nstdout:',
+      resFromShell.stdout.toString(),
+      '\nstderr:',
+      resFromShell.stderr.toString(),
+      '\n',
+      String(error)
+    )
+    throw error
+  }
+}
 
 describe('command runner', () => {
   it('should return stdout', async () => {
     const cmd = command('echo', 'hello world')
-    const res = await cmd.run()
 
-    expect(res.exitCode).toEqual(0)
-    expect(res.stdout.toString().trim()).toEqual('hello world')
-    expect(res.stderr.toString().trim()).toEqual('')
+    await testCommand(cmd, (res) => {
+      expect(res.exitCode).toEqual(0)
+      expect(res.stdout.toString().trim()).toEqual('hello world')
+      expect(res.stderr.toString().trim()).toEqual('')
+    })
   })
 
-  it('should return stderr', async() => {
+  it('should return stderr', async () => {
     const cmd = command('>&2 echo', 'hello world')
-    const res = await cmd.run()
 
-    expect(res.exitCode).toEqual(0)
-    expect(res.stdout.toString().trim()).toEqual('')
-    expect(res.stderr.toString().trim()).toEqual('hello world')
+    await testCommand(cmd, (res) => {
+      expect(res.exitCode).toEqual(0)
+      expect(res.stdout.toString().trim()).toEqual('')
+      expect(res.stderr.toString().trim()).toEqual('hello world')
+    })
   })
 
-  it('should return exit code', async() => {
+  it('should return exit code', async () => {
     const cmd = command('exit', '42')
-    const res = await cmd.run()
 
-    expect(res.exitCode).toEqual(42)
-    expect(res.stdout.toString().trim()).toEqual('')
-    expect(res.stderr.toString().trim()).toEqual('')
+    await testCommand(cmd, (res) => {
+      expect(res.exitCode).toEqual(42)
+      expect(res.stdout.toString().trim()).toEqual('')
+      expect(res.stderr.toString().trim()).toEqual('')
+    })
   })
 
-  it('should pipe stdout to stdin', async() => {
+  it('should pipe stdout to stdin', async () => {
     const s = 'hello world'
 
     const cmd = command('echo', s)
       .pipe(command('tr', '-d', '\\r'))
       .pipe(command('tr', '-d', '\\n'))
       .pipe(command('wc', '-c'))
-    const res = await cmd.run()
 
-    expect(res.exitCode).toEqual(0)
-    expect(res.stdout.toString().trim()).toEqual(`${s.length}`)
-    expect(res.stderr.toString().trim()).toEqual('')
+    await testCommand(cmd, (res) => {
+      expect(res.exitCode).toEqual(0)
+      expect(res.stdout.toString().trim()).toEqual(`${s.length}`)
+      expect(res.stderr.toString().trim()).toEqual('')
+    })
   })
 
-  it('should chain commands with &&', async() => {
-    const cmd = command('printf', '"hello "')
-      .and(command('printf', 'world'))
-    const res = await cmd.run()
+  it('should chain commands with &&', async () => {
+    const cmd = command('printf', 'hello ').and(command('printf', 'world'))
 
-    expect(res.exitCode).toEqual(0)
-    expect(res.stdout.toString().trim()).toEqual('hello world')
-    expect(res.stderr.toString().trim()).toEqual('')
+    await testCommand(cmd, (res) => {
+      expect(res.exitCode).toEqual(0)
+      expect(res.stdout.toString().trim()).toEqual('hello world')
+      expect(res.stderr.toString().trim()).toEqual('')
+    })
   })
 
-  it('should short-circuit on failure with &&', async() => {
-    const cmd = command('exit', '1')
-      .and(command('echo', 'hello world'))
-    const res = await cmd.run()
+  it('should short-circuit on failure with &&', async () => {
+    const cmd = command('exit', '1').and(command('echo', 'hello world'))
 
-    expect(res.exitCode).toEqual(1)
-    expect(res.stdout.toString().trim()).toEqual('')
-    expect(res.stderr.toString().trim()).toEqual('')
+    await testCommand(cmd, (res) => {
+      expect(res.exitCode).toEqual(1)
+      expect(res.stdout.toString().trim()).toEqual('')
+      expect(res.stderr.toString().trim()).toEqual('')
+    })
   })
 
-  it('should chain commands with ||', async() => {
-    const cmd = command('exit', '1')
-      .or(command('echo', 'hello world'))
-    const res = await cmd.run()
+  it('should chain commands with ||', async () => {
+    const cmd = command('exit', '1').or(command('echo', 'hello world'))
 
-    expect(res.exitCode).toEqual(0)
-    expect(res.stdout.toString().trim()).toEqual('hello world')
-    expect(res.stderr.toString().trim()).toEqual('')
+    await testCommand(cmd, (res) => {
+      expect(res.exitCode).toEqual(0)
+      expect(res.stdout.toString().trim()).toEqual('hello world')
+      expect(res.stderr.toString().trim()).toEqual('')
+    })
   })
 
-  it('should short-circuit on success with ||', async() => {
-    const cmd = command('echo', 'hello world')
-      .or(command('exit', '1'))
-    const res = await cmd.run()
+  it('should short-circuit on success with ||', async () => {
+    const cmd = command('echo', 'hello world').or(command('exit', '1'))
 
-    expect(res.exitCode).toEqual(0)
-    expect(res.stdout.toString().trim()).toEqual('hello world')
-    expect(res.stderr.toString().trim()).toEqual('')
+    await testCommand(cmd, (res) => {
+      expect(res.exitCode).toEqual(0)
+      expect(res.stdout.toString().trim()).toEqual('hello world')
+      expect(res.stderr.toString().trim()).toEqual('')
+    })
   })
 
-  it('should redirect stdout to a file', async() => {
-    const folder = await fs.mkdtemp(path.join(os.tmpdir(), 'tshellout-test-stdout-'))
+  it('should redirect stdout to a file', async () => {
+    const folder = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'tshellout-test-stdout-')
+    )
     const filepath = path.join(folder, 'stdout.txt')
+    const cmd = command('echo', 'hello world').redirectStdout(filepath)
 
     try {
-      const cmd = command('echo', 'hello world').redirectStdout(filepath)
-      const res = await cmd.run()
+      await testCommand(cmd, async (res) => {
+        expect(res.exitCode).toEqual(0)
+        expect(res.stdout.toString().trim()).toEqual('')
+        expect(res.stderr.toString().trim()).toEqual('')
 
-      expect(res.exitCode).toEqual(0)
-      expect(res.stdout.toString().trim()).toEqual('')
-      expect(res.stderr.toString().trim()).toEqual('')
-
-      const content = await fs.readFile(filepath)
-      expect(content.toString().trim()).toEqual('hello world')
-    }
-    finally {
+        const content = await fs.readFile(filepath)
+        expect(content.toString().trim()).toEqual('hello world')
+      })
+    } finally {
       await fs.rm(folder, { recursive: true, force: true })
     }
   })
 
-  it('should redirect stderr to a file', async() => {
-    const folder = await fs.mkdtemp(path.join(os.tmpdir(), 'tshellout-test-stderr-'))
+  it('should redirect stderr to a file', async () => {
+    const folder = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'tshellout-test-stderr-')
+    )
     const filepath = path.join(folder, 'stderr.txt')
+    const cmd = command('>&2 echo', 'hello world').redirectStderr(filepath)
 
     try {
-      const cmd = command('>&2 echo', 'hello world').redirectStderr(filepath)
-      const res = await cmd.run()
+      await testCommand(cmd, async (res) => {
+        expect(res.exitCode).toEqual(0)
+        expect(res.stdout.toString().trim()).toEqual('')
+        expect(res.stderr.toString().trim()).toEqual('')
 
-      expect(res.exitCode).toEqual(0)
-      expect(res.stdout.toString().trim()).toEqual('')
-      expect(res.stderr.toString().trim()).toEqual('')
-
-      const content = await fs.readFile(filepath)
-      expect(content.toString().trim()).toEqual('hello world')
-    }
-    finally {
+        const content = await fs.readFile(filepath)
+        expect(content.toString().trim()).toEqual('hello world')
+      })
+    } finally {
       await fs.rm(folder, { recursive: true, force: true })
     }
   })
 
-  it('should redirect a file to stdin', async() => {
-    const folder = await fs.mkdtemp(path.join(os.tmpdir(), 'tshellout-test-stdin-'))
+  it('should redirect a file to stdin', async () => {
+    const folder = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'tshellout-test-stdin-')
+    )
     const filepath = path.join(folder, 'stdin.txt')
 
     try {
       await fs.writeFile(filepath, 'hello world\n')
 
       const cmd = command('cat').redirectStdin(filepath)
-      const res = await cmd.run()
-
-      expect(res.exitCode).toEqual(0)
-      expect(res.stdout.toString().trim()).toEqual('hello world')
-      expect(res.stderr.toString().trim()).toEqual('')
-    }
-    finally {
+      await testCommand(cmd, (res) => {
+        expect(res.exitCode).toEqual(0)
+        expect(res.stdout.toString().trim()).toEqual('hello world')
+        expect(res.stderr.toString().trim()).toEqual('')
+      })
+    } finally {
       await fs.rm(folder, { recursive: true, force: true })
     }
   })
 
-  it('should write to stdin', async() => {
-    const cmd = command('cat')
-      .writeStdin(Buffer.from('hello world\n'))
-    const res = await cmd.run()
+  it('should write to stdin', async () => {
+    const cmd = command('cat').writeStdin(Buffer.from('hello world\n'))
 
-    expect(res.exitCode).toEqual(0)
-    expect(res.stdout.toString().trim()).toEqual('hello world')
-    expect(res.stderr.toString().trim()).toEqual('')
+    await testCommand(cmd, (res) => {
+      expect(res.exitCode).toEqual(0)
+      expect(res.stdout.toString().trim()).toEqual('hello world')
+      expect(res.stderr.toString().trim()).toEqual('')
+    })
+  })
+})
+
+describe('command template literal', () => {
+  it('shell-escapes interpolated strings', () => {
+    snapshotCommand(command`echo ${'hello world'}`)
+  })
+
+  it('inserts interpolated commands literally', () => {
+    const innerCmd = command`exit 0`
+    const cmd = command`echo Running command: ${innerCmd}`
+    snapshotCommand(cmd)
+  })
+
+  it('omits interpolated null | undefined', () => {
+    snapshotCommand(command`echo ${null} hi`)
+    snapshotCommand(command`echo ${undefined} bye`)
   })
 })


### PR DESCRIPTION
The advantage of using an API like `command("my-exe, "install", pkg)` is to safely pass arguments to the executable without worrying about injection. If we want the arguments to be shell-expanded (eg interpreting quotes and variable substitution), it would take fewer keystrokes to write: 

```typescript
command(`my-exe install ${pkg}`)
```

### escape arguments

So, I was surprised to find that your library enables shell execution for commands & arguments. Shell expanding arguments should not be the default! This means it's super easy to make mistakes when passing filenames to commands, since spaces in the filename will break the argument. For example:

```typescript
async function cleanUp(location: string) {
  await command.run('rm', '-rf', location)
}

await cleanUp('Documents/Project Name/hi.txt')
```

Running that script will delete `Documents/Project` and `Name/hi.txt`.

Instead, we should always safely shell-escape arguments passed to `command(...)`.

## Tagged template literal

We can combine the brevity of template strings with automatic shell escaping using a tagged template literal function.

```typescript
const location = 'Documents/Project Name/hi.txt'

// Bad - deletes "Documents/Project" and "Name/hi.txt"
command(`rm -rf ${location}`).run()

// Good - deletes "Documents/Project Name/hi.txt"
command('rm', '-rf', location)

// Best - less typing, still deletes  "Documents/Project Name/hi.txt"
command`rm -rf ${location}`.run()
```

The way this works is that we overload `command` to accept a `TemplateStringsArray` argument, and to shell escape any interpolated strings. If users want to interpolate a string without it being shell-escaped, they can interpolate another `CommandBuilder` instance. For example:

```typescript
async function install(destination?: string) {
  const PREFIX = command`"$PREFIX"`
 await  command`cp ./pkg/foo ${destination ?? PREFIX}/share/foo`.run()
}
```