### PR TITLE
:bug: Fix shell injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ console.log(res.stderr.toString())
 More examples:
 
 ```typescript
-// echo hello world | tr -d \r | tr -d \n | wc -c
+// echo "hello world" | tr -d "\r" | tr -d "\n" | wc -c
 const cmd = command('echo', 'hello world')
-  .pipe(command('tr', '-d', '\\r'))
-  .pipe(command('tr', '-d', '\\n'))
+  .pipe(command('tr', '-d', '"\\r"'))
+  .pipe(command('tr', '-d', '"\\n"'))
   .pipe(command('wc', '-c'))
 const res = await cmd.run()
 ```
@@ -65,7 +65,7 @@ const res = await cmd.run()
 ```
 
 ```typescript
-// echo hello world > greet.txt
+// echo "hello world" > greet.txt
 const cmd = command('echo', 'hello world')
   .redirectStdout('greet.txt')
 const res = await cmd.run()

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -12,12 +12,24 @@ export interface Stdio {
   terminated: Promise<void>,
 }
 
+const quote = (s: string): string => {
+  if ((/["\s]/).test(s) && !(/'/).test(s)) {
+    return "'" + s.replace(/(['\\])/g, '\\$1') + "'"
+  }
+
+  if ((/["'\s]/).test(s)) {
+    return '"' + s.replace(/(["\\$`!])/g, '\\$1') + '"'
+  }
+
+  return s.replace(/([A-Za-z]:)?([#!"$&'()*,:;<=>?@[\\\]^`{|}])/g, '$1\\$2')
+}
+
 const evalCommand = async (node: Command): Promise<Stdio> => {
   switch (node.type) {
     case 'spawn': {
       const child = spawn(
         node.executable,
-        node.args,
+        node.args.map(quote),
         {
           shell: true,
           stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Decision Record

The arguments of a command should be sanitized before being passed to the `spawn()` function. This includes escaping dangerous characters and spaces, and adding quotes.

Consider the following:

```typescript
await command('rm', 'hello world.txt').run()
```

With unsanitized arguments, it will remove the files `hello` and `world.txt` instead of the file `hello world.txt`.

Thank you @justjake for the suggestion, for more informations, see:

 - #1

## Changes

 - [x] :bug: Add a `quote` function to sanitize the arguments
 - [x] :white_check_mark: Update test suite to also work on Windows (which uses `cmd.exe` as shell)
