### PR TITLE
:sparkles: Add `exec()` method which does not capture output

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,34 @@ const cmd = command('cat')
 const res = await cmd.run()
 ```
 
+We can also avoid capturing the output, and raise on errors:
+
+```typescript
+await command('echo', 'hello world').exec()
+```
+
+Parameters of both `run()` and `exec()` methods can be overridden:
+
+```typescript
+class CommandBuilder {
+  // ...
+  async run(options?: {
+    capture: { stdout: boolean, stderr: boolean },
+    raiseOnError: boolean,
+  }) { /* ... */ }
+
+  async exec(options?: {
+    capture: { stdout: boolean, stderr: boolean },
+    raiseOnError: boolean,
+  }) { /* ... */ }
+}
+```
+
+The defaults are:
+
+  - `run()`: `{ capture: { stdout: true, stderr: true }, raiseOnError: false }`
+  - `exec()`: `{ capture: { stdout: false, stderr: false }, raiseOnError: true }`
+
 ## :page_facing_up: License
 
 This project is released under the terms of the [MIT License](./LICENSE.txt).


### PR DESCRIPTION
## Decision Record

The `run()` method captures `stdout` and `stderr` by default and will ignore errors, to return an object with the exit code and captured outputs.

In CI/CD scripts, we might want to simply execute the command, not capturing the output, and raise whenever an error occurs.

## Changes

 - [x] :sparkles: Add `exec()` method which does not capture output and raise on errors