### PR TITLE
:sparkles: Add `script` tagged template function

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm i tshellout
 Then in a script:
 
 ```typescript
-import command from 'tshellout'
+import { command, script } from 'tshellout'
 
 const cmd = command('echo', 'hello world')
 const res = await cmd.run()
@@ -85,6 +85,21 @@ const res = await cmd.run()
 const cmd = command('cat')
   .writeStdin(Buffer.from('hello world\n'))
 const res = await cmd.run()
+```
+
+We can also execute scripts:
+
+```typescript
+const cmd = script`
+  echo hello
+  echo world
+`
+
+// equivalent to:
+
+const cmd = command('true')
+  .and(command('echo hello'))
+  .and(command('echo world'))
 ```
 
 We can also avoid capturing the output, and raise on errors:

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -12,7 +12,7 @@ export interface Stdio {
   terminated: Promise<void>,
 }
 
-const quote = (s: string): string => {
+export const quote = (s: string): string => {
   if ((/["\s]/).test(s) && !(/'/).test(s)) {
     return "'" + s.replace(/(['\\])/g, '\\$1') + "'"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,1 @@
-import { command } from './builder'
-
-export default command
+export { command, script } from './builder'

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import os from 'node:os'
 
-import command from '../src/index'
+import { command, script } from '../src/index'
 
 const isWindows = os.platform() === 'win32'
 
@@ -174,6 +174,23 @@ describe('command runner', () => {
 
     expect(res.exitCode).toEqual(0)
     expect(res.stdout.toString().trim()).toEqual('hello world')
+    expect(res.stderr.toString().trim()).toEqual('')
+  })
+
+  it('should execute a script', async() => {
+    const res = await script`
+      echo hello
+      echo world
+    `.run()
+
+    expect(res.exitCode).toEqual(0)
+    expect(
+      res.stdout.toString()
+        .split('\n')
+        .map(s => s.trim())
+        .filter(s => s.length > 0)
+        .join(' ')
+    ).toEqual('hello world')
     expect(res.stderr.toString().trim()).toEqual('')
   })
 })


### PR DESCRIPTION
## Decision Record

To further simplify writing scripts, we want a tagged template function to allow us to chain commands:

```typescript
await script`
  echo hello
  echo world
`.exec()
```

Which would be equivalent to:

```typescript
const cmd = command('true')
  .and('echo hello')
  .and('echo world')
await cmd.exec()
```

We chain commands using `and()` to simulate `set -x` in Bash. This is an opinionated choice. IMHO, silencing errors should never happen in a shell script. We also prepend the command chain with `true` so that empty scripts do succeed:

```typescript
await script`       `.exec() // succeeds
```

Thank you @justjake for the suggestion, for more information, see:

 - #1

## Changes

 - [x] :sparkles: Add `script` tagged template function
 - [x] :white_check_mark: Add test case for `script` tagged template function