### PR TITLE
:sparkles: :recycle: Provide `script.posix` and `script.powershell` template tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ const res = await cmd.run()
 We can also execute scripts:
 
 ```typescript
-const cmd = script`
+const cmd = script.posix`
+  set -x
   echo hello
   echo world
 `

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tshellout",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeScript Shell-out library",
   "repository": "https://github.com/linkdd/tshellout",
   "author": "David Delassus <david.jose.delassus@gmail.com>",

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -178,7 +178,7 @@ describe('command runner', () => {
   })
 
   it('should execute a script', async() => {
-    const res = await script`
+    const res = await script.posix`
       echo hello
       echo world
     `.run()


### PR DESCRIPTION
## Decision Record

As mentioned in this [discussion](https://github.com/linkdd/tshellout/pull/4#discussion_r1272427516), the `script` template tag as-is can lead to shell injection.

The current behavior is to split the string by `;` and use each parts as a command and then chain them together.

However, the following command will be wrongly split:

```
git commit -m "Fix shell injection; add shell injection warnings"
```

To add the cherry on top, The `script` simulated `set -x` by calling `true` as the first command, which would not work on every platform.

Therefore, to fix those issues, we introduce 2 templates tags: `script.posix` and `script.powershell`. The string is given to either `/bin/sh` or `PowerShell` via stdin:

 - `sh -`
 - `PowerShell -Command -`

`cmd.exe` does not support reading from stdin, so support for it will be ignored.

Example usage:

```typescript
await script.posix`
  set -x
  echo hello
  echo world
`
```

## Changes

 - [x] :sparkles: Add `script.posix` template tag to run the script in a POSIX (`sh`) shell
 - [x] :sparkles: Add `script.powershell` template tag to run the script in PowerShell